### PR TITLE
Refactor page logic into custom hook

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,636 +2,21 @@
 
 "use client";
 
-import React, { useState, useRef, useMemo, useCallback } from "react";
-import { useVirtualizer } from "@tanstack/react-virtual";
 import debounce from "lodash/debounce";
-
-import { Person, ReceiptItem, EditableItem, SharedReceipt } from "@/types";
-
 import PeopleTab from "@/components/PeopleTab";
 import ReceiptTab from "@/components/ReceiptTab";
 import SplitItemsTab from "@/components/SplitItemsTab";
 import DragSplitTab from "@/components/DragSplitTab";
 import SummaryTab from "@/components/SummaryTab";
 import SplitDialog from "@/components/SplitDialog";
-
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
-import {
-  UploadIcon,
-  Camera,
-  Loader2,
-  Globe,
-  Eye,
-  Grip,
-  ArrowLeft,
-  Plus,
-  Download,
-  Users,
-  Receipt,
-  Calculator,
-} from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Separator } from "@/components/ui/separator";
+import { Grip, Users, Receipt, Calculator } from "lucide-react";
 
-import { processReceiptOCR } from "./actions/ocr";
-import { publishReceipt } from "./actions/share";
+import { useMoneySplit } from "@/hooks/use-money-split";
 
 export default function MoneySplitApp() {
-  // ─── state definitions ─────────────────────────────────────────────────
-  const [people, setPeople] = useState<Person[]>([]);
-  const [newPersonName, setNewPersonName] = useState("");
-  const [receiptItems, setReceiptItems] = useState<ReceiptItem[]>([]);
-  const [newItemName, setNewItemName] = useState("");
-  const [newItemPrice, setNewItemPrice] = useState("");
-  const [activeTab, setActiveTab] = useState("people");
-  const [isProcessingOCR, setIsProcessingOCR] = useState(false);
-  const [ocrError, setOcrError] = useState<string | null>(null);
-  const [ocrSuccess, setOcrSuccess] = useState<string | null>(null);
-  const [selectedLanguage, setSelectedLanguage] = useState("auto");
-  const [editableItems, setEditableItems] = useState<EditableItem[]>([]);
-  const [showPersonItems, setShowPersonItems] = useState<string | null>(null);
-  const [draggedItem, setDraggedItem] = useState<ReceiptItem | null>(null);
-  const [showSplitDialog, setShowSplitDialog] = useState(false);
-  const [splitDialogType, setSplitDialogType] = useState<"equal" | "unequal">(
-    "equal"
-  );
-  const [tempEqualSplitPeople, setTempEqualSplitPeople] = useState<string[]>(
-    []
-  );
-  const [tempUnequalSplit, setTempUnequalSplit] = useState<
-    { personId: string; amount: number }[]
-  >([]);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [pageSize, setPageSize] = useState(10);
-  const [splitItemsPage, setSplitItemsPage] = useState(1);
-  const [splitItemsPageSize, setSplitItemsPageSize] = useState(5);
-  const [unsplitItemsPage, setUnsplitItemsPage] = useState(1);
-  const [unsplitItemsPageSize, setUnsplitItemsPageSize] = useState(5);
-  const [isPublishing, setIsPublishing] = useState(false);
-  const [publishedUrl, setPublishedUrl] = useState<string | null>(null);
-  const [receiptTitle, setReceiptTitle] = useState("");
-
-  const fileInputRef = useRef<HTMLInputElement>(
-    null!
-  ) as React.RefObject<HTMLInputElement>;
-
-  // ─── “People” Tab 相關函式 ────────────────────────────────────────────────
-  const addPerson = () => {
-    if (newPersonName.trim()) {
-      const newPerson: Person = {
-        id: Date.now().toString(),
-        name: newPersonName.trim(),
-      };
-      setPeople([...people, newPerson]);
-      setNewPersonName("");
-    }
-  };
-
-  const removePerson = (id: string) => {
-    setPeople(people.filter((p) => p.id !== id));
-    // 如果某人被刪除，所有已指定給他(她)的項目也要處理
-    setReceiptItems((items) =>
-      items.map((item) => ({
-        ...item,
-        assignedTo: item.assignedTo === id ? undefined : item.assignedTo,
-        equalSplitPeople: item.equalSplitPeople?.filter((pid) => pid !== id),
-        unequalSplit: item.unequalSplit?.filter(
-          (split) => split.personId !== id
-        ),
-        splitType: item.assignedTo === id ? "unsplit" : item.splitType,
-      }))
-    );
-  };
-
-  // ─── “Receipt” Tab 相關函式 ───────────────────────────────────────────────
-  const addReceiptItem = useCallback(() => {
-    if (newItemName.trim() && newItemPrice.trim()) {
-      setReceiptItems((prev) => [
-        ...prev,
-        {
-          id: Date.now().toString(),
-          name: newItemName.trim(),
-          price: Number.parseFloat(newItemPrice),
-          splitType: "unsplit",
-        },
-      ]);
-      setNewItemName("");
-      setNewItemPrice("");
-    }
-  }, [newItemName, newItemPrice]);
-
-  const removeReceiptItem = (id: string) => {
-    setReceiptItems(receiptItems.filter((item) => item.id !== id));
-  };
-
-  const handleReceiptUpload = async (
-    event: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    const file = event.target.files?.[0];
-    if (!file) return;
-
-    setIsProcessingOCR(true);
-    setOcrError(null);
-    setOcrSuccess(null);
-
-    try {
-      const formData = new FormData();
-      formData.append("receipt", file);
-      formData.append("language", selectedLanguage);
-
-      const result = await processReceiptOCR(formData);
-
-      if (result.success && result.items && result.items.length > 0) {
-        // OCR 回傳的 items 先轉成可編輯的格式
-        const newEditableItems: EditableItem[] = result.items.map(
-          (item, index) => ({
-            id: (Date.now() + index).toString(),
-            name: item.name,
-            price: item.price.toString(),
-            isEditing: false,
-          })
-        );
-
-        setEditableItems(newEditableItems);
-        setActiveTab("receipt");
-        setOcrSuccess(
-          `Successfully extracted ${result.items.length} items from your receipt!`
-        );
-        setOcrError(null);
-      } else if (result.success && result.items && result.items.length === 0) {
-        setOcrError(
-          "No items with prices were found in the receipt. You can add items manually below."
-        );
-      } else {
-        setOcrError(result.error || "Failed to process receipt");
-      }
-    } catch (error) {
-      setOcrError("Error processing receipt. Please try again.");
-    } finally {
-      setIsProcessingOCR(false);
-      event.target.value = "";
-    }
-  };
-
-  const updateEditableItem = (
-    id: string,
-    field: "name" | "price",
-    value: string
-  ) => {
-    setEditableItems((items) =>
-      items.map((item) => (item.id === id ? { ...item, [field]: value } : item))
-    );
-  };
-
-  const startEditingItem = (id: string) => {
-    setEditableItems((items) =>
-      items.map((item) =>
-        item.id === id ? { ...item, isEditing: true } : item
-      )
-    );
-  };
-
-  const saveEditableItem = (id: string) => {
-    setEditableItems((items) =>
-      items.map((item) =>
-        item.id === id ? { ...item, isEditing: false } : item
-      )
-    );
-  };
-
-  const removeEditableItem = (id: string) => {
-    setEditableItems((items) => items.filter((item) => item.id !== id));
-  };
-
-  const addEditableItemsToReceipt = () => {
-    const newItems: ReceiptItem[] = editableItems.map((item) => ({
-      id: item.id,
-      name: item.name,
-      price: Number.parseFloat(item.price) || 0,
-      splitType: "unsplit",
-    }));
-
-    setReceiptItems((prev) => [...prev, ...newItems]);
-    setEditableItems([]);
-  };
-
-  const exportData = () => {
-    const data = {
-      people,
-      receiptItems,
-      exportDate: new Date().toISOString(),
-    };
-
-    const blob = new Blob([JSON.stringify(data, null, 2)], {
-      type: "application/json",
-    });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `money-split-${new Date().toISOString().split("T")[0]}.json`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
-  };
-
-  const importData = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (!file) return;
-
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      try {
-        const data = JSON.parse(e.target?.result as string);
-        if (data.people && data.receiptItems) {
-          setPeople(data.people);
-          setReceiptItems(data.receiptItems);
-          setOcrSuccess("Data imported successfully!");
-        } else {
-          setOcrError("Invalid file format");
-        }
-      } catch (error) {
-        setOcrError("Error reading file");
-      }
-    };
-    reader.readAsText(file);
-    event.target.value = "";
-  };
-
-  // ─── “Split Items” Tab 相關函式 ───────────────────────────────────────────
-  const updateItemSplitType = (
-    itemId: string,
-    splitType: "individual" | "equal" | "unequal" | "unsplit"
-  ) => {
-    setReceiptItems((items) =>
-      items.map((item) =>
-        item.id === itemId
-          ? {
-              ...item,
-              splitType,
-              assignedTo: undefined,
-              equalSplitPeople: [],
-              unequalSplit: [],
-            }
-          : item
-      )
-    );
-  };
-
-  const updateIndividualAssignment = (itemId: string, personId: string) => {
-    setReceiptItems((items) =>
-      items.map((item) =>
-        item.id === itemId
-          ? { ...item, assignedTo: personId, splitType: "individual" }
-          : item
-      )
-    );
-  };
-
-  const updateEqualSplitPeople = (
-    itemId: string,
-    personId: string,
-    checked: boolean
-  ) => {
-    setReceiptItems((items) =>
-      items.map((item) => {
-        if (item.id === itemId) {
-          const currentPeople = item.equalSplitPeople || [];
-          const updatedPeople = checked
-            ? [...currentPeople, personId]
-            : currentPeople.filter((id) => id !== personId);
-          return { ...item, equalSplitPeople: updatedPeople };
-        }
-        return item;
-      })
-    );
-  };
-
-  const selectAllForEqualSplit = (itemId: string, selectAll: boolean) => {
-    setReceiptItems((items) =>
-      items.map((item) => {
-        if (item.id === itemId) {
-          return {
-            ...item,
-            equalSplitPeople: selectAll ? people.map((p) => p.id) : [],
-          };
-        }
-        return item;
-      })
-    );
-  };
-
-  const updateUnequalSplit = (
-    itemId: string,
-    personId: string,
-    amount: number
-  ) => {
-    setReceiptItems((items) =>
-      items.map((item) => {
-        if (item.id === itemId) {
-          const currentSplit = item.unequalSplit || [];
-          const existingIndex = currentSplit.findIndex(
-            (split) => split.personId === personId
-          );
-
-          let updatedSplit;
-          if (existingIndex >= 0) {
-            if (amount === 0) {
-              updatedSplit = currentSplit.filter(
-                (split) => split.personId !== personId
-              );
-            } else {
-              updatedSplit = currentSplit.map((split) =>
-                split.personId === personId ? { ...split, amount } : split
-              );
-            }
-          } else if (amount > 0) {
-            updatedSplit = [...currentSplit, { personId, amount }];
-          } else {
-            updatedSplit = currentSplit;
-          }
-
-          return { ...item, unequalSplit: updatedSplit };
-        }
-        return item;
-      })
-    );
-  };
-
-  const resetItemToUnsplit = (itemId: string) => {
-    setReceiptItems((items) =>
-      items.map((item) =>
-        item.id === itemId
-          ? {
-              ...item,
-              splitType: "unsplit",
-              assignedTo: undefined,
-              equalSplitPeople: [],
-              unequalSplit: [],
-            }
-          : item
-      )
-    );
-  };
-
-  // ─── “Visual Split” Tab 相關函式 ───────────────────────────────────────────
-  const handleDragStart = (item: ReceiptItem) => {
-    setDraggedItem(item);
-  };
-
-  const handleDragOver = (e: React.DragEvent) => {
-    e.preventDefault();
-  };
-
-  const handleDropOnPerson = (personId: string) => {
-    if (draggedItem) {
-      updateIndividualAssignment(draggedItem.id, personId);
-      setDraggedItem(null);
-    }
-  };
-
-  const handleDropOnSplitArea = (splitType: "equal" | "unequal") => {
-    if (draggedItem) {
-      setSplitDialogType(splitType);
-      if (splitType === "equal") {
-        setTempEqualSplitPeople(people.map((p) => p.id));
-      } else {
-        setTempUnequalSplit(people.map((p) => ({ personId: p.id, amount: 0 })));
-      }
-      setShowSplitDialog(true);
-    }
-  };
-
-  const confirmSplit = () => {
-    if (!draggedItem) return;
-
-    if (splitDialogType === "equal") {
-      setReceiptItems((items) =>
-        items.map((item) =>
-          item.id === draggedItem.id
-            ? {
-                ...item,
-                splitType: "equal",
-                equalSplitPeople: tempEqualSplitPeople,
-              }
-            : item
-        )
-      );
-    } else {
-      setReceiptItems((items) =>
-        items.map((item) =>
-          item.id === draggedItem.id
-            ? { ...item, splitType: "unequal", unequalSplit: tempUnequalSplit }
-            : item
-        )
-      );
-    }
-
-    setShowSplitDialog(false);
-    setDraggedItem(null);
-    setTempEqualSplitPeople([]);
-    setTempUnequalSplit([]);
-    setOcrError(null);
-  };
-
-  const cancelSplit = () => {
-    setShowSplitDialog(false);
-    setDraggedItem(null);
-    setTempEqualSplitPeople([]);
-    setTempUnequalSplit([]);
-  };
-
-  const validateEqualSplit = () => {
-    return tempEqualSplitPeople.length > 0;
-  };
-
-  const validateUnequalSplit = () => {
-    if (!draggedItem) return false;
-    const totalSplit = tempUnequalSplit.reduce(
-      (sum, split) => sum + split.amount,
-      0
-    );
-    const itemTotal = Number(draggedItem.price.toFixed(2));
-    return Math.abs(totalSplit - itemTotal) < 0.01;
-  };
-
-  const getSplitValidationMessage = () => {
-    if (!draggedItem) return "";
-
-    if (splitDialogType === "equal") {
-      if (tempEqualSplitPeople.length === 0) {
-        return "Please select at least one person";
-      }
-    } else {
-      const totalSplit = tempUnequalSplit.reduce(
-        (sum, split) => sum + split.amount,
-        0
-      );
-      const itemTotal = Number(draggedItem.price.toFixed(2));
-      if (Math.abs(totalSplit - itemTotal) >= 0.01) {
-        return `Split total ($${totalSplit.toFixed(
-          2
-        )}) must equal item price ($${itemTotal.toFixed(2)})`;
-      }
-    }
-    return "";
-  };
-
-  // ─── “Summary” Tab 所需函式 ──────────────────────────────────────────────
-  const calculateTotals = () => {
-    const totals: { [personId: string]: number } = {};
-    people.forEach((person) => {
-      totals[person.id] = 0;
-    });
-
-    receiptItems.forEach((item) => {
-      if (item.splitType === "individual" && item.assignedTo) {
-        totals[item.assignedTo] = (totals[item.assignedTo] || 0) + item.price;
-      } else if (
-        item.splitType === "equal" &&
-        item.equalSplitPeople &&
-        item.equalSplitPeople.length > 0
-      ) {
-        const splitAmount = item.price / item.equalSplitPeople.length;
-        item.equalSplitPeople.forEach((personId) => {
-          totals[personId] = (totals[personId] || 0) + splitAmount;
-        });
-      } else if (item.splitType === "unequal" && item.unequalSplit) {
-        item.unequalSplit.forEach((split) => {
-          totals[split.personId] = (totals[split.personId] || 0) + split.amount;
-        });
-      }
-    });
-
-    return totals;
-  };
-
-  const getPersonItems = (personId: string) => {
-    const items: Array<{ item: ReceiptItem; amount: number; type: string }> =
-      [];
-
-    receiptItems.forEach((item) => {
-      if (item.splitType === "individual" && item.assignedTo === personId) {
-        items.push({ item, amount: item.price, type: "Individual" });
-      } else if (
-        item.splitType === "equal" &&
-        item.equalSplitPeople?.includes(personId)
-      ) {
-        const splitAmount = item.price / (item.equalSplitPeople?.length || 1);
-        items.push({ item, amount: splitAmount, type: "Equal Split" });
-      } else if (item.splitType === "unequal" && item.unequalSplit) {
-        const split = item.unequalSplit.find((s) => s.personId === personId);
-        if (split) {
-          items.push({ item, amount: split.amount, type: "Custom Split" });
-        }
-      }
-    });
-
-    return items;
-  };
-
-  // ─── 分頁 & 計算函式 ─────────────────────────────────────────────────────
-  const paginatedItems = useMemo(() => {
-    const startIndex = (currentPage - 1) * pageSize;
-    const endIndex = startIndex + pageSize;
-    return receiptItems.slice(startIndex, endIndex);
-  }, [receiptItems, currentPage, pageSize]);
-
-  const totalPages = Math.ceil(receiptItems.length / pageSize);
-
-  const paginatedSplitItems = useMemo(() => {
-    const startIndex = (splitItemsPage - 1) * splitItemsPageSize;
-    const endIndex = startIndex + splitItemsPageSize;
-    return receiptItems.slice(startIndex, endIndex);
-  }, [receiptItems, splitItemsPage, splitItemsPageSize]);
-
-  const totalSplitPages = Math.ceil(receiptItems.length / splitItemsPageSize);
-
-  const unsplitItems = useMemo(() => {
-    return receiptItems.filter((item) => item.splitType === "unsplit");
-  }, [receiptItems]);
-
-  const splitItemsByPerson = useMemo(() => {
-    const splitItems: { [personId: string]: ReceiptItem[] } = {};
-    people.forEach((person) => {
-      splitItems[person.id] = [];
-    });
-
-    receiptItems.forEach((item) => {
-      if (item.splitType === "individual" && item.assignedTo) {
-        splitItems[item.assignedTo].push(item);
-      } else if (item.splitType === "equal" && item.equalSplitPeople) {
-        item.equalSplitPeople.forEach((personId) => {
-          splitItems[personId].push(item);
-        });
-      } else if (item.splitType === "unequal" && item.unequalSplit) {
-        item.unequalSplit.forEach((split) => {
-          splitItems[split.personId].push(item);
-        });
-      }
-    });
-
-    return splitItems;
-  }, [receiptItems, people]);
-
-  const totalUnsplitPages = Math.ceil(
-    unsplitItems.length / unsplitItemsPageSize
-  );
-
-  const paginatedUnsplitItems = useMemo(() => {
-    const filteredUnsplit = unsplitItems;
-    const startIndex = (unsplitItemsPage - 1) * unsplitItemsPageSize;
-    const endIndex = startIndex + unsplitItemsPageSize;
-
-    if (startIndex >= filteredUnsplit.length && unsplitItemsPage > 1) {
-      setUnsplitItemsPage(1);
-      return filteredUnsplit.slice(0, unsplitItemsPageSize);
-    }
-
-    return filteredUnsplit.slice(startIndex, endIndex);
-  }, [unsplitItemsPage, unsplitItemsPageSize, unsplitItems]);
-
-  const grandTotal = useMemo(
-    () => receiptItems.reduce((sum, item) => sum + item.price, 0),
-    [receiptItems]
-  );
-
-  // 使用 virtualizer (若要進行效能優化，可自行調整)
-  const parentRef = useRef<HTMLDivElement>(null);
-  const rowVirtualizer = useVirtualizer({
-    count: receiptItems.length,
-    getScrollElement: () => parentRef.current,
-    estimateSize: () => 70,
-    overscan: 5,
-  });
-
-  // ─── Publish Receipt ─────────────────────────────────────────────────────
-  const handlePublishReceipt = async () => {
-    setIsPublishing(true);
-    try {
-      const id = crypto.randomUUID();
-      const receiptData: SharedReceipt = {
-        id,
-        title: receiptTitle || "Unnamed Receipt",
-        people,
-        items: receiptItems,
-        totals: calculateTotals(),
-        grandTotal: receiptItems.reduce((sum, item) => sum + item.price, 0),
-        createdAt: new Date().toISOString(),
-      };
-
-      const url = await publishReceipt(receiptData);
-      setPublishedUrl(id);
-    } catch (error) {
-      console.error("Error publishing receipt:", error);
-      setOcrError("Failed to publish receipt");
-    } finally {
-      setIsPublishing(false);
-    }
-  };
-
-  // ─── 介面渲染 ─────────────────────────────────────────────────────────────
+  const ms = useMoneySplit();
 
   return (
     <div className="container mx-auto p-4 max-w-6xl">
@@ -639,15 +24,13 @@ export default function MoneySplitApp() {
         <div className="flex items-center gap-3">
           <img src="/logo.png" alt="Logo" className="w-10 h-10 dark:invert" />
           <div>
-            <h1 className="text-3xl font-medium tracking-tight">
-              Splitwise Mini
-            </h1>
+            <h1 className="text-3xl font-medium tracking-tight">Splitwise Mini</h1>
           </div>
         </div>
         <ThemeToggle />
       </div>
 
-      <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+      <Tabs value={ms.activeTab} onValueChange={ms.setActiveTab} className="w-full">
         <TabsList className="grid w-full grid-cols-5">
           <TabsTrigger value="people" className="flex items-center gap-2">
             <Users className="h-4 w-4" />
@@ -674,122 +57,121 @@ export default function MoneySplitApp() {
         {/* People Tab */}
         <TabsContent value="people" className="space-y-4">
           <PeopleTab
-            people={people}
-            newPersonName={newPersonName}
-            setNewPersonName={setNewPersonName}
-            addPerson={addPerson}
-            removePerson={removePerson}
+            people={ms.people}
+            newPersonName={ms.newPersonName}
+            setNewPersonName={ms.setNewPersonName}
+            addPerson={ms.addPerson}
+            removePerson={ms.removePerson}
           />
         </TabsContent>
 
         {/* Receipt Tab */}
         <TabsContent value="receipt" className="space-y-4">
           <ReceiptTab
-            people={people}
-            receiptItems={receiptItems}
-            editableItems={editableItems}
-            newItemName={newItemName}
-            newItemPrice={newItemPrice}
-            selectedLanguage={selectedLanguage}
-            isProcessingOCR={isProcessingOCR}
-            ocrError={ocrError}
-            ocrSuccess={ocrSuccess}
-            receiptTitle={receiptTitle}
-            grandTotal={grandTotal}
-            currentPage={currentPage}
-            pageSize={pageSize}
-            totalPages={totalPages}
-            paginatedItems={paginatedItems}
-            fileInputRef={fileInputRef}
-            setSelectedLanguage={setSelectedLanguage}
-            handleReceiptUpload={handleReceiptUpload}
-            exportData={exportData}
-            importData={importData}
-            updateEditableItem={debounce(updateEditableItem, 150)}
-            startEditingItem={startEditingItem}
-            saveEditableItem={saveEditableItem}
-            removeEditableItem={removeEditableItem}
-            addEditableItemsToReceipt={addEditableItemsToReceipt}
-            addReceiptItem={addReceiptItem}
-            removeReceiptItem={removeReceiptItem}
-            setNewItemName={setNewItemName}
-            setNewItemPrice={setNewItemPrice}
-            setCurrentPage={setCurrentPage}
+            people={ms.people}
+            receiptItems={ms.receiptItems}
+            editableItems={ms.editableItems}
+            newItemName={ms.newItemName}
+            newItemPrice={ms.newItemPrice}
+            selectedLanguage={ms.selectedLanguage}
+            isProcessingOCR={ms.isProcessingOCR}
+            ocrError={ms.ocrError}
+            ocrSuccess={ms.ocrSuccess}
+            receiptTitle={ms.receiptTitle}
+            grandTotal={ms.grandTotal}
+            currentPage={ms.currentPage}
+            pageSize={ms.pageSize}
+            totalPages={ms.totalPages}
+            paginatedItems={ms.paginatedItems}
+            fileInputRef={ms.fileInputRef}
+            setSelectedLanguage={ms.setSelectedLanguage}
+            handleReceiptUpload={ms.handleReceiptUpload}
+            exportData={ms.exportData}
+            importData={ms.importData}
+            updateEditableItem={debounce(ms.updateEditableItem, 150)}
+            startEditingItem={ms.startEditingItem}
+            saveEditableItem={ms.saveEditableItem}
+            removeEditableItem={ms.removeEditableItem}
+            addEditableItemsToReceipt={ms.addEditableItemsToReceipt}
+            addReceiptItem={ms.addReceiptItem}
+            removeReceiptItem={ms.removeReceiptItem}
+            setNewItemName={ms.setNewItemName}
+            setNewItemPrice={ms.setNewItemPrice}
+            setCurrentPage={ms.setCurrentPage}
           />
         </TabsContent>
 
         {/* Split Items Tab */}
         <TabsContent value="split" className="space-y-4">
           <SplitItemsTab
-            receiptItems={receiptItems}
-            people={people}
-            splitItemsPage={splitItemsPage}
-            splitItemsPageSize={splitItemsPageSize}
-            totalSplitPages={totalSplitPages}
-            paginatedSplitItems={paginatedSplitItems}
-            setSplitItemsPage={setSplitItemsPage}
-            setSplitItemsPageSize={setSplitItemsPageSize}
-            updateItemSplitType={updateItemSplitType}
-            updateIndividualAssignment={updateIndividualAssignment}
-            updateEqualSplitPeople={updateEqualSplitPeople}
-            selectAllForEqualSplit={selectAllForEqualSplit}
-            updateUnequalSplit={updateUnequalSplit}
+            receiptItems={ms.receiptItems}
+            people={ms.people}
+            splitItemsPage={ms.splitItemsPage}
+            splitItemsPageSize={ms.splitItemsPageSize}
+            totalSplitPages={ms.totalSplitPages}
+            paginatedSplitItems={ms.paginatedSplitItems}
+            setSplitItemsPage={ms.setSplitItemsPage}
+            setSplitItemsPageSize={ms.setSplitItemsPageSize}
+            updateItemSplitType={ms.updateItemSplitType}
+            updateIndividualAssignment={ms.updateIndividualAssignment}
+            updateEqualSplitPeople={ms.updateEqualSplitPeople}
+            selectAllForEqualSplit={ms.selectAllForEqualSplit}
+            updateUnequalSplit={ms.updateUnequalSplit}
           />
         </TabsContent>
 
         {/* Drag-Split Tab */}
         <TabsContent value="drag-split" className="space-y-4">
           <DragSplitTab
-            people={people}
-            totals={calculateTotals()}
-            unsplitItems={unsplitItems}
-            splitItemsByPerson={splitItemsByPerson}
-            paginatedUnsplitItems={paginatedUnsplitItems}
-            unsplitItemsPage={unsplitItemsPage}
-            totalUnsplitPages={totalUnsplitPages}
-            setUnsplitItemsPage={setUnsplitItemsPage}
-            draggedItem={draggedItem}
-            handleDragStart={handleDragStart}
-            // handleDragOver={handleDragOver}
-            handleDropOnPerson={handleDropOnPerson}
-            handleDropOnSplitArea={handleDropOnSplitArea}
-            unsplitItemsCount={unsplitItems.length}
-            resetItemToUnsplit={resetItemToUnsplit}
+            people={ms.people}
+            totals={ms.calculateTotals()}
+            unsplitItems={ms.unsplitItems}
+            splitItemsByPerson={ms.splitItemsByPerson}
+            paginatedUnsplitItems={ms.paginatedUnsplitItems}
+            unsplitItemsPage={ms.unsplitItemsPage}
+            totalUnsplitPages={ms.totalUnsplitPages}
+            setUnsplitItemsPage={ms.setUnsplitItemsPage}
+            draggedItem={ms.draggedItem}
+            handleDragStart={ms.handleDragStart}
+            handleDropOnPerson={ms.handleDropOnPerson}
+            handleDropOnSplitArea={ms.handleDropOnSplitArea}
+            unsplitItemsCount={ms.unsplitItems.length}
+            resetItemToUnsplit={ms.resetItemToUnsplit}
           />
         </TabsContent>
 
         {/* Summary Tab */}
         <TabsContent value="summary" className="space-y-4">
           <SummaryTab
-            people={people}
-            totals={calculateTotals()}
-            grandTotal={grandTotal}
-            getPersonItems={getPersonItems}
-            unsplitItems={unsplitItems}
-            receiptTitle={receiptTitle}
-            isPublishing={isPublishing}
-            setReceiptTitle={setReceiptTitle}
-            handlePublishReceipt={handlePublishReceipt}
-            publishedUrl={publishedUrl}
+            people={ms.people}
+            totals={ms.calculateTotals()}
+            grandTotal={ms.grandTotal}
+            getPersonItems={ms.getPersonItems}
+            unsplitItems={ms.unsplitItems}
+            receiptTitle={ms.receiptTitle}
+            isPublishing={ms.isPublishing}
+            setReceiptTitle={ms.setReceiptTitle}
+            handlePublishReceipt={ms.handlePublishReceipt}
+            publishedUrl={ms.publishedUrl}
           />
         </TabsContent>
       </Tabs>
 
       {/* Split Dialog (全域掛載) */}
       <SplitDialog
-        open={showSplitDialog}
-        onClose={cancelSplit}
-        splitDialogType={splitDialogType}
-        draggedItem={draggedItem}
-        people={people}
-        tempEqualSplitPeople={tempEqualSplitPeople}
-        setTempEqualSplitPeople={setTempEqualSplitPeople}
-        tempUnequalSplit={tempUnequalSplit}
-        setTempUnequalSplit={setTempUnequalSplit}
-        validateEqualSplit={validateEqualSplit}
-        validateUnequalSplit={validateUnequalSplit}
-        getSplitValidationMessage={getSplitValidationMessage}
-        confirmSplit={confirmSplit}
+        open={ms.showSplitDialog}
+        onClose={ms.cancelSplit}
+        splitDialogType={ms.splitDialogType}
+        draggedItem={ms.draggedItem}
+        people={ms.people}
+        tempEqualSplitPeople={ms.tempEqualSplitPeople}
+        setTempEqualSplitPeople={ms.setTempEqualSplitPeople}
+        tempUnequalSplit={ms.tempUnequalSplit}
+        setTempUnequalSplit={ms.setTempUnequalSplit}
+        validateEqualSplit={ms.validateEqualSplit}
+        validateUnequalSplit={ms.validateUnequalSplit}
+        getSplitValidationMessage={ms.getSplitValidationMessage}
+        confirmSplit={ms.confirmSplit}
       />
     </div>
   );

--- a/hooks/use-money-split.tsx
+++ b/hooks/use-money-split.tsx
@@ -1,42 +1,51 @@
-'use client'
+"use client";
 
-import React, { useState, useRef, useMemo, useCallback } from 'react'
-import { useVirtualizer } from '@tanstack/react-virtual'
+import React, { useState, useRef, useMemo, useCallback } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 
-import { Person, ReceiptItem, EditableItem, SharedReceipt } from '@/types'
-import { processReceiptOCR } from '@/app/actions/ocr'
-import { publishReceipt } from '@/app/actions/share'
+import { Person, ReceiptItem, EditableItem, SharedReceipt } from "@/types";
+import { processReceiptOCR } from "@/app/actions/ocr";
+import { publishReceipt } from "@/app/actions/share";
+import { get } from "lodash";
 
 export function useMoneySplit() {
   // ─── state definitions ─────────────────────────────────────────────────
-  const [people, setPeople] = useState<Person[]>([])
-  const [newPersonName, setNewPersonName] = useState('')
-  const [receiptItems, setReceiptItems] = useState<ReceiptItem[]>([])
-  const [newItemName, setNewItemName] = useState('')
-  const [newItemPrice, setNewItemPrice] = useState('')
-  const [activeTab, setActiveTab] = useState('people')
-  const [isProcessingOCR, setIsProcessingOCR] = useState(false)
-  const [ocrError, setOcrError] = useState<string | null>(null)
-  const [ocrSuccess, setOcrSuccess] = useState<string | null>(null)
-  const [selectedLanguage, setSelectedLanguage] = useState('auto')
-  const [editableItems, setEditableItems] = useState<EditableItem[]>([])
-  const [showPersonItems, setShowPersonItems] = useState<string | null>(null)
-  const [draggedItem, setDraggedItem] = useState<ReceiptItem | null>(null)
-  const [showSplitDialog, setShowSplitDialog] = useState(false)
-  const [splitDialogType, setSplitDialogType] = useState<'equal' | 'unequal'>('equal')
-  const [tempEqualSplitPeople, setTempEqualSplitPeople] = useState<string[]>([])
-  const [tempUnequalSplit, setTempUnequalSplit] = useState<{ personId: string; amount: number }[]>([])
-  const [currentPage, setCurrentPage] = useState(1)
-  const [pageSize, setPageSize] = useState(10)
-  const [splitItemsPage, setSplitItemsPage] = useState(1)
-  const [splitItemsPageSize, setSplitItemsPageSize] = useState(5)
-  const [unsplitItemsPage, setUnsplitItemsPage] = useState(1)
-  const [unsplitItemsPageSize, setUnsplitItemsPageSize] = useState(5)
-  const [isPublishing, setIsPublishing] = useState(false)
-  const [publishedUrl, setPublishedUrl] = useState<string | null>(null)
-  const [receiptTitle, setReceiptTitle] = useState('')
+  const [people, setPeople] = useState<Person[]>([]);
+  const [newPersonName, setNewPersonName] = useState("");
+  const [receiptItems, setReceiptItems] = useState<ReceiptItem[]>([]);
+  const [newItemName, setNewItemName] = useState("");
+  const [newItemPrice, setNewItemPrice] = useState("");
+  const [activeTab, setActiveTab] = useState("people");
+  const [isProcessingOCR, setIsProcessingOCR] = useState(false);
+  const [ocrError, setOcrError] = useState<string | null>(null);
+  const [ocrSuccess, setOcrSuccess] = useState<string | null>(null);
+  const [selectedLanguage, setSelectedLanguage] = useState("auto");
+  const [editableItems, setEditableItems] = useState<EditableItem[]>([]);
+  const [showPersonItems, setShowPersonItems] = useState<string | null>(null);
+  const [draggedItem, setDraggedItem] = useState<ReceiptItem | null>(null);
+  const [showSplitDialog, setShowSplitDialog] = useState(false);
+  const [splitDialogType, setSplitDialogType] = useState<"equal" | "unequal">(
+    "equal"
+  );
+  const [tempEqualSplitPeople, setTempEqualSplitPeople] = useState<string[]>(
+    []
+  );
+  const [tempUnequalSplit, setTempUnequalSplit] = useState<
+    { personId: string; amount: number }[]
+  >([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+  const [splitItemsPage, setSplitItemsPage] = useState(1);
+  const [splitItemsPageSize, setSplitItemsPageSize] = useState(5);
+  const [unsplitItemsPage, setUnsplitItemsPage] = useState(1);
+  const [unsplitItemsPageSize, setUnsplitItemsPageSize] = useState(5);
+  const [isPublishing, setIsPublishing] = useState(false);
+  const [publishedUrl, setPublishedUrl] = useState<string | null>(null);
+  const [receiptTitle, setReceiptTitle] = useState("");
 
-  const fileInputRef = useRef<HTMLInputElement>(null) as React.RefObject<HTMLInputElement>
+  const fileInputRef = useRef<HTMLInputElement>(
+    null
+  ) as React.RefObject<HTMLInputElement>;
 
   // ─── “People” Tab 相關函式 ────────────────────────────────────────────────
   const addPerson = () => {
@@ -44,24 +53,26 @@ export function useMoneySplit() {
       const newPerson: Person = {
         id: Date.now().toString(),
         name: newPersonName.trim(),
-      }
-      setPeople([...people, newPerson])
-      setNewPersonName('')
+      };
+      setPeople([...people, newPerson]);
+      setNewPersonName("");
     }
-  }
+  };
 
   const removePerson = (id: string) => {
-    setPeople(people.filter((p) => p.id !== id))
+    setPeople(people.filter((p) => p.id !== id));
     setReceiptItems((items) =>
       items.map((item) => ({
         ...item,
         assignedTo: item.assignedTo === id ? undefined : item.assignedTo,
         equalSplitPeople: item.equalSplitPeople?.filter((pid) => pid !== id),
-        unequalSplit: item.unequalSplit?.filter((split) => split.personId !== id),
-        splitType: item.assignedTo === id ? 'unsplit' : item.splitType,
+        unequalSplit: item.unequalSplit?.filter(
+          (split) => split.personId !== id
+        ),
+        splitType: item.assignedTo === id ? "unsplit" : item.splitType,
       }))
-    )
-  }
+    );
+  };
 
   // ─── “Receipt” Tab 相關函式 ───────────────────────────────────────────────
   const addReceiptItem = useCallback(() => {
@@ -72,131 +83,155 @@ export function useMoneySplit() {
           id: Date.now().toString(),
           name: newItemName.trim(),
           price: Number.parseFloat(newItemPrice),
-          splitType: 'unsplit',
+          splitType: "unsplit",
         },
-      ])
-      setNewItemName('')
-      setNewItemPrice('')
+      ]);
+      setNewItemName("");
+      setNewItemPrice("");
     }
-  }, [newItemName, newItemPrice])
+  }, [newItemName, newItemPrice]);
 
   const removeReceiptItem = (id: string) => {
-    setReceiptItems(receiptItems.filter((item) => item.id !== id))
-  }
+    setReceiptItems(receiptItems.filter((item) => item.id !== id));
+  };
 
-  const handleReceiptUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0]
-    if (!file) return
+  const handleReceiptUpload = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
 
-    setIsProcessingOCR(true)
-    setOcrError(null)
-    setOcrSuccess(null)
+    setIsProcessingOCR(true);
+    setOcrError(null);
+    setOcrSuccess(null);
 
     try {
-      const formData = new FormData()
-      formData.append('receipt', file)
-      formData.append('language', selectedLanguage)
+      const formData = new FormData();
+      formData.append("receipt", file);
+      formData.append("language", selectedLanguage);
 
-      const result = await processReceiptOCR(formData)
+      const result = await processReceiptOCR(formData);
 
       if (result.success && result.items && result.items.length > 0) {
-        const newEditableItems: EditableItem[] = result.items.map((item, index) => ({
-          id: (Date.now() + index).toString(),
-          name: item.name,
-          price: item.price.toString(),
-          isEditing: false,
-        }))
+        const newEditableItems: EditableItem[] = result.items.map(
+          (item, index) => ({
+            id: (Date.now() + index).toString(),
+            name: item.name,
+            price: item.price.toString(),
+            isEditing: false,
+          })
+        );
 
-        setEditableItems(newEditableItems)
-        setActiveTab('receipt')
-        setOcrSuccess(`Successfully extracted ${result.items.length} items from your receipt!`)
-        setOcrError(null)
+        setEditableItems(newEditableItems);
+        setActiveTab("receipt");
+        setOcrSuccess(
+          `Successfully extracted ${result.items.length} items from your receipt!`
+        );
+        setOcrError(null);
       } else if (result.success && result.items && result.items.length === 0) {
-        setOcrError('No items with prices were found in the receipt. You can add items manually below.')
+        setOcrError(
+          "No items with prices were found in the receipt. You can add items manually below."
+        );
       } else {
-        setOcrError(result.error || 'Failed to process receipt')
+        setOcrError(result.error || "Failed to process receipt");
       }
     } catch (error) {
-      setOcrError('Error processing receipt. Please try again.')
+      setOcrError("Error processing receipt. Please try again.");
     } finally {
-      setIsProcessingOCR(false)
-      event.target.value = ''
+      setIsProcessingOCR(false);
+      event.target.value = "";
     }
-  }
+  };
 
-  const updateEditableItem = (id: string, field: 'name' | 'price', value: string) => {
-    setEditableItems((items) => items.map((item) => (item.id === id ? { ...item, [field]: value } : item)))
-  }
+  const updateEditableItem = (
+    id: string,
+    field: "name" | "price",
+    value: string
+  ) => {
+    setEditableItems((items) =>
+      items.map((item) => (item.id === id ? { ...item, [field]: value } : item))
+    );
+  };
 
   const startEditingItem = (id: string) => {
-    setEditableItems((items) => items.map((item) => (item.id === id ? { ...item, isEditing: true } : item)))
-  }
+    setEditableItems((items) =>
+      items.map((item) =>
+        item.id === id ? { ...item, isEditing: true } : item
+      )
+    );
+  };
 
   const saveEditableItem = (id: string) => {
-    setEditableItems((items) => items.map((item) => (item.id === id ? { ...item, isEditing: false } : item)))
-  }
+    setEditableItems((items) =>
+      items.map((item) =>
+        item.id === id ? { ...item, isEditing: false } : item
+      )
+    );
+  };
 
   const removeEditableItem = (id: string) => {
-    setEditableItems((items) => items.filter((item) => item.id !== id))
-  }
+    setEditableItems((items) => items.filter((item) => item.id !== id));
+  };
 
   const addEditableItemsToReceipt = () => {
     const newItems: ReceiptItem[] = editableItems.map((item) => ({
       id: item.id,
       name: item.name,
       price: Number.parseFloat(item.price) || 0,
-      splitType: 'unsplit',
-    }))
+      splitType: "unsplit",
+    }));
 
-    setReceiptItems((prev) => [...prev, ...newItems])
-    setEditableItems([])
-  }
+    setReceiptItems((prev) => [...prev, ...newItems]);
+    setEditableItems([]);
+  };
 
   const exportData = () => {
     const data = {
       people,
       receiptItems,
       exportDate: new Date().toISOString(),
-    }
+    };
 
-    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `money-split-${new Date().toISOString().split('T')[0]}.json`
-    document.body.appendChild(a)
-    a.click()
-    document.body.removeChild(a)
-    URL.revokeObjectURL(url)
-  }
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `money-split-${new Date().toISOString().split("T")[0]}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
 
   const importData = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0]
-    if (!file) return
+    const file = event.target.files?.[0];
+    if (!file) return;
 
-    const reader = new FileReader()
+    const reader = new FileReader();
     reader.onload = (e) => {
       try {
-        const data = JSON.parse(e.target?.result as string)
+        const data = JSON.parse(e.target?.result as string);
         if (data.people && data.receiptItems) {
-          setPeople(data.people)
-          setReceiptItems(data.receiptItems)
-          setOcrSuccess('Data imported successfully!')
+          setPeople(data.people);
+          setReceiptItems(data.receiptItems);
+          setOcrSuccess("Data imported successfully!");
         } else {
-          setOcrError('Invalid file format')
+          setOcrError("Invalid file format");
         }
       } catch (error) {
-        setOcrError('Error reading file')
+        setOcrError("Error reading file");
       }
-    }
-    reader.readAsText(file)
-    event.target.value = ''
-  }
+    };
+    reader.readAsText(file);
+    event.target.value = "";
+  };
 
   // ─── “Split Items” Tab 相關函式 ───────────────────────────────────────────
   const updateItemSplitType = (
     itemId: string,
-    splitType: 'individual' | 'equal' | 'unequal' | 'unsplit'
+    splitType: "individual" | "equal" | "unequal" | "unsplit"
   ) => {
     setReceiptItems((items) =>
       items.map((item) =>
@@ -210,29 +245,37 @@ export function useMoneySplit() {
             }
           : item
       )
-    )
-  }
+    );
+  };
 
   const updateIndividualAssignment = (itemId: string, personId: string) => {
     setReceiptItems((items) =>
       items.map((item) =>
-        item.id === itemId ? { ...item, assignedTo: personId, splitType: 'individual' } : item
+        item.id === itemId
+          ? { ...item, assignedTo: personId, splitType: "individual" }
+          : item
       )
-    )
-  }
+    );
+  };
 
-  const updateEqualSplitPeople = (itemId: string, personId: string, checked: boolean) => {
+  const updateEqualSplitPeople = (
+    itemId: string,
+    personId: string,
+    checked: boolean
+  ) => {
     setReceiptItems((items) =>
       items.map((item) => {
         if (item.id === itemId) {
-          const currentPeople = item.equalSplitPeople || []
-          const updatedPeople = checked ? [...currentPeople, personId] : currentPeople.filter((id) => id !== personId)
-          return { ...item, equalSplitPeople: updatedPeople }
+          const currentPeople = item.equalSplitPeople || [];
+          const updatedPeople = checked
+            ? [...currentPeople, personId]
+            : currentPeople.filter((id) => id !== personId);
+          return { ...item, equalSplitPeople: updatedPeople };
         }
-        return item
+        return item;
       })
-    )
-  }
+    );
+  };
 
   const selectAllForEqualSplit = (itemId: string, selectAll: boolean) => {
     setReceiptItems((items) =>
@@ -241,39 +284,49 @@ export function useMoneySplit() {
           return {
             ...item,
             equalSplitPeople: selectAll ? people.map((p) => p.id) : [],
-          }
+          };
         }
-        return item
+        return item;
       })
-    )
-  }
+    );
+  };
 
-  const updateUnequalSplit = (itemId: string, personId: string, amount: number) => {
+  const updateUnequalSplit = (
+    itemId: string,
+    personId: string,
+    amount: number
+  ) => {
     setReceiptItems((items) =>
       items.map((item) => {
         if (item.id === itemId) {
-          const currentSplit = item.unequalSplit || []
-          const existingIndex = currentSplit.findIndex((split) => split.personId === personId)
+          const currentSplit = item.unequalSplit || [];
+          const existingIndex = currentSplit.findIndex(
+            (split) => split.personId === personId
+          );
 
-          let updatedSplit
+          let updatedSplit;
           if (existingIndex >= 0) {
             if (amount === 0) {
-              updatedSplit = currentSplit.filter((split) => split.personId !== personId)
+              updatedSplit = currentSplit.filter(
+                (split) => split.personId !== personId
+              );
             } else {
-              updatedSplit = currentSplit.map((split) => (split.personId === personId ? { ...split, amount } : split))
+              updatedSplit = currentSplit.map((split) =>
+                split.personId === personId ? { ...split, amount } : split
+              );
             }
           } else if (amount > 0) {
-            updatedSplit = [...currentSplit, { personId, amount }]
+            updatedSplit = [...currentSplit, { personId, amount }];
           } else {
-            updatedSplit = currentSplit
+            updatedSplit = currentSplit;
           }
 
-          return { ...item, unequalSplit: updatedSplit }
+          return { ...item, unequalSplit: updatedSplit };
         }
-        return item
+        return item;
       })
-    )
-  }
+    );
+  };
 
   const resetItemToUnsplit = (itemId: string) => {
     setReceiptItems((items) =>
@@ -281,250 +334,270 @@ export function useMoneySplit() {
         item.id === itemId
           ? {
               ...item,
-              splitType: 'unsplit',
+              splitType: "unsplit",
               assignedTo: undefined,
               equalSplitPeople: [],
               unequalSplit: [],
             }
           : item
       )
-    )
-  }
+    );
+  };
 
   // ─── “Visual Split” Tab 相關函式 ───────────────────────────────────────────
   const handleDragStart = (item: ReceiptItem) => {
-    setDraggedItem(item)
-  }
+    setDraggedItem(item);
+  };
 
   const handleDragOver = (e: React.DragEvent) => {
-    e.preventDefault()
-  }
+    e.preventDefault();
+  };
 
   const handleDropOnPerson = (personId: string) => {
     if (draggedItem) {
-      updateIndividualAssignment(draggedItem.id, personId)
-      setDraggedItem(null)
+      updateIndividualAssignment(draggedItem.id, personId);
+      setDraggedItem(null);
     }
-  }
+  };
 
-  const handleDropOnSplitArea = (splitType: 'equal' | 'unequal') => {
+  const handleDropOnSplitArea = (splitType: "equal" | "unequal") => {
     if (draggedItem) {
-      setSplitDialogType(splitType)
-      if (splitType === 'equal') {
-        setTempEqualSplitPeople(people.map((p) => p.id))
+      setSplitDialogType(splitType);
+      if (splitType === "equal") {
+        setTempEqualSplitPeople(people.map((p) => p.id));
       } else {
-        setTempUnequalSplit(people.map((p) => ({ personId: p.id, amount: 0 })))
+        setTempUnequalSplit(people.map((p) => ({ personId: p.id, amount: 0 })));
       }
-      setShowSplitDialog(true)
+      setShowSplitDialog(true);
     }
-  }
+  };
 
   const confirmSplit = () => {
-    if (!draggedItem) return
+    if (!draggedItem) return;
 
-    if (splitDialogType === 'equal') {
+    if (splitDialogType === "equal") {
       setReceiptItems((items) =>
         items.map((item) =>
           item.id === draggedItem.id
             ? {
                 ...item,
-                splitType: 'equal',
+                splitType: "equal",
                 equalSplitPeople: tempEqualSplitPeople,
               }
             : item
         )
-      )
+      );
     } else {
       setReceiptItems((items) =>
         items.map((item) =>
-          item.id === draggedItem.id ? { ...item, splitType: 'unequal', unequalSplit: tempUnequalSplit } : item
+          item.id === draggedItem.id
+            ? { ...item, splitType: "unequal", unequalSplit: tempUnequalSplit }
+            : item
         )
-      )
+      );
     }
 
-    setShowSplitDialog(false)
-    setDraggedItem(null)
-    setTempEqualSplitPeople([])
-    setTempUnequalSplit([])
-    setOcrError(null)
-  }
+    setShowSplitDialog(false);
+    setDraggedItem(null);
+    setTempEqualSplitPeople([]);
+    setTempUnequalSplit([]);
+    setOcrError(null);
+  };
 
   const cancelSplit = () => {
-    setShowSplitDialog(false)
-    setDraggedItem(null)
-    setTempEqualSplitPeople([])
-    setTempUnequalSplit([])
-  }
+    setShowSplitDialog(false);
+    setDraggedItem(null);
+    setTempEqualSplitPeople([]);
+    setTempUnequalSplit([]);
+  };
 
   const validateEqualSplit = () => {
-    return tempEqualSplitPeople.length > 0
-  }
+    return tempEqualSplitPeople.length > 0;
+  };
 
   const validateUnequalSplit = () => {
-    if (!draggedItem) return false
-    const totalSplit = tempUnequalSplit.reduce((sum, split) => sum + split.amount, 0)
-    const itemTotal = Number(draggedItem.price.toFixed(2))
-    return Math.abs(totalSplit - itemTotal) < 0.01
-  }
+    if (!draggedItem) return false;
+    const totalSplit = tempUnequalSplit.reduce(
+      (sum, split) => sum + split.amount,
+      0
+    );
+    const itemTotal = Number(draggedItem.price.toFixed(2));
+    return Math.abs(totalSplit - itemTotal) < 0.01;
+  };
 
   const getSplitValidationMessage = () => {
-    if (!draggedItem) return ''
+    if (!draggedItem) return "";
 
-    if (splitDialogType === 'equal') {
+    if (splitDialogType === "equal") {
       if (tempEqualSplitPeople.length === 0) {
-        return 'Please select at least one person'
+        return "Please select at least one person";
       }
     } else {
-      const totalSplit = tempUnequalSplit.reduce((sum, split) => sum + split.amount, 0)
-      const itemTotal = Number(draggedItem.price.toFixed(2))
+      const totalSplit = tempUnequalSplit.reduce(
+        (sum, split) => sum + split.amount,
+        0
+      );
+      const itemTotal = Number(draggedItem.price.toFixed(2));
       if (Math.abs(totalSplit - itemTotal) >= 0.01) {
-        return `Split total ($${totalSplit.toFixed(2)}) must equal item price ($${itemTotal.toFixed(2)})`
+        return `Split total ($${totalSplit.toFixed(
+          2
+        )}) must equal item price ($${itemTotal.toFixed(2)})`;
       }
     }
-    return ''
-  }
+    return "";
+  };
 
   // ─── “Summary” Tab 所需函式 ──────────────────────────────────────────────
   const calculateTotals = () => {
-    const totals: { [personId: string]: number } = {}
+    const totals: { [personId: string]: number } = {};
     people.forEach((person) => {
-      totals[person.id] = 0
-    })
+      totals[person.id] = 0;
+    });
 
     receiptItems.forEach((item) => {
-      if (item.splitType === 'individual' && item.assignedTo) {
-        totals[item.assignedTo] = (totals[item.assignedTo] || 0) + item.price
-      } else if (item.splitType === 'equal' && item.equalSplitPeople && item.equalSplitPeople.length > 0) {
-        const splitAmount = item.price / item.equalSplitPeople.length
+      if (item.splitType === "individual" && item.assignedTo) {
+        totals[item.assignedTo] = (totals[item.assignedTo] || 0) + item.price;
+      } else if (
+        item.splitType === "equal" &&
+        item.equalSplitPeople &&
+        item.equalSplitPeople.length > 0
+      ) {
+        const splitAmount = item.price / item.equalSplitPeople.length;
         item.equalSplitPeople.forEach((personId) => {
-          totals[personId] = (totals[personId] || 0) + splitAmount
-        })
-      } else if (item.splitType === 'unequal' && item.unequalSplit) {
+          totals[personId] = (totals[personId] || 0) + splitAmount;
+        });
+      } else if (item.splitType === "unequal" && item.unequalSplit) {
         item.unequalSplit.forEach((split) => {
-          totals[split.personId] = (totals[split.personId] || 0) + split.amount
-        })
+          totals[split.personId] = (totals[split.personId] || 0) + split.amount;
+        });
       }
-    })
+    });
 
-    return totals
-  }
+    return totals;
+  };
 
   const getPersonItems = (personId: string) => {
-    const items: Array<{ item: ReceiptItem; amount: number; type: string }> = []
+    const items: Array<{ item: ReceiptItem; amount: number; type: string }> =
+      [];
 
     receiptItems.forEach((item) => {
-      if (item.splitType === 'individual' && item.assignedTo === personId) {
-        items.push({ item, amount: item.price, type: 'Individual' })
-      } else if (item.splitType === 'equal' && item.equalSplitPeople?.includes(personId)) {
-        const splitAmount = item.price / (item.equalSplitPeople?.length || 1)
-        items.push({ item, amount: splitAmount, type: 'Equal Split' })
-      } else if (item.splitType === 'unequal' && item.unequalSplit) {
-        const split = item.unequalSplit.find((s) => s.personId === personId)
+      if (item.splitType === "individual" && item.assignedTo === personId) {
+        items.push({ item, amount: item.price, type: "Individual" });
+      } else if (
+        item.splitType === "equal" &&
+        item.equalSplitPeople?.includes(personId)
+      ) {
+        const splitAmount = item.price / (item.equalSplitPeople?.length || 1);
+        items.push({ item, amount: splitAmount, type: "Equal Split" });
+      } else if (item.splitType === "unequal" && item.unequalSplit) {
+        const split = item.unequalSplit.find((s) => s.personId === personId);
         if (split) {
-          items.push({ item, amount: split.amount, type: 'Custom Split' })
+          items.push({ item, amount: split.amount, type: "Custom Split" });
         }
       }
-    })
+    });
 
-    return items
-  }
+    return items;
+  };
 
   // ─── 分頁 & 計算函式 ─────────────────────────────────────────────────────
   const paginatedItems = useMemo(() => {
-    const startIndex = (currentPage - 1) * pageSize
-    const endIndex = startIndex + pageSize
-    return receiptItems.slice(startIndex, endIndex)
-  }, [receiptItems, currentPage, pageSize])
+    const startIndex = (currentPage - 1) * pageSize;
+    const endIndex = startIndex + pageSize;
+    return receiptItems.slice(startIndex, endIndex);
+  }, [receiptItems, currentPage, pageSize]);
 
-  const totalPages = Math.ceil(receiptItems.length / pageSize)
+  const totalPages = Math.ceil(receiptItems.length / pageSize);
 
   const paginatedSplitItems = useMemo(() => {
-    const startIndex = (splitItemsPage - 1) * splitItemsPageSize
-    const endIndex = startIndex + splitItemsPageSize
-    return receiptItems.slice(startIndex, endIndex)
-  }, [receiptItems, splitItemsPage, splitItemsPageSize])
+    const startIndex = (splitItemsPage - 1) * splitItemsPageSize;
+    const endIndex = startIndex + splitItemsPageSize;
+    return receiptItems.slice(startIndex, endIndex);
+  }, [receiptItems, splitItemsPage, splitItemsPageSize]);
 
-  const totalSplitPages = Math.ceil(receiptItems.length / splitItemsPageSize)
+  const totalSplitPages = Math.ceil(receiptItems.length / splitItemsPageSize);
 
   const unsplitItems = useMemo(() => {
-    return receiptItems.filter((item) => item.splitType === 'unsplit')
-  }, [receiptItems])
+    return receiptItems.filter((item) => item.splitType === "unsplit");
+  }, [receiptItems]);
 
   const splitItemsByPerson = useMemo(() => {
-    const splitItems: { [personId: string]: ReceiptItem[] } = {}
+    const splitItems: { [personId: string]: ReceiptItem[] } = {};
     people.forEach((person) => {
-      splitItems[person.id] = []
-    })
+      splitItems[person.id] = [];
+    });
 
     receiptItems.forEach((item) => {
-      if (item.splitType === 'individual' && item.assignedTo) {
-        splitItems[item.assignedTo].push(item)
-      } else if (item.splitType === 'equal' && item.equalSplitPeople) {
+      if (item.splitType === "individual" && item.assignedTo) {
+        splitItems[item.assignedTo].push(item);
+      } else if (item.splitType === "equal" && item.equalSplitPeople) {
         item.equalSplitPeople.forEach((personId) => {
-          splitItems[personId].push(item)
-        })
-      } else if (item.splitType === 'unequal' && item.unequalSplit) {
+          splitItems[personId].push(item);
+        });
+      } else if (item.splitType === "unequal" && item.unequalSplit) {
         item.unequalSplit.forEach((split) => {
-          splitItems[split.personId].push(item)
-        })
+          splitItems[split.personId].push(item);
+        });
       }
-    })
+    });
 
-    return splitItems
-  }, [receiptItems, people])
+    return splitItems;
+  }, [receiptItems, people]);
 
-  const totalUnsplitPages = Math.ceil(unsplitItems.length / unsplitItemsPageSize)
+  const totalUnsplitPages = Math.ceil(
+    unsplitItems.length / unsplitItemsPageSize
+  );
 
   const paginatedUnsplitItems = useMemo(() => {
-    const filteredUnsplit = unsplitItems
-    const startIndex = (unsplitItemsPage - 1) * unsplitItemsPageSize
-    const endIndex = startIndex + unsplitItemsPageSize
+    const filteredUnsplit = unsplitItems;
+    const startIndex = (unsplitItemsPage - 1) * unsplitItemsPageSize;
+    const endIndex = startIndex + unsplitItemsPageSize;
 
     if (startIndex >= filteredUnsplit.length && unsplitItemsPage > 1) {
-      setUnsplitItemsPage(1)
-      return filteredUnsplit.slice(0, unsplitItemsPageSize)
+      setUnsplitItemsPage(1);
+      return filteredUnsplit.slice(0, unsplitItemsPageSize);
     }
 
-    return filteredUnsplit.slice(startIndex, endIndex)
-  }, [unsplitItemsPage, unsplitItemsPageSize, unsplitItems])
+    return filteredUnsplit.slice(startIndex, endIndex);
+  }, [unsplitItemsPage, unsplitItemsPageSize, unsplitItems]);
 
   const grandTotal = useMemo(
     () => receiptItems.reduce((sum, item) => sum + item.price, 0),
     [receiptItems]
-  )
+  );
 
-  const parentRef = useRef<HTMLDivElement>(null)
+  const parentRef = useRef<HTMLDivElement>(null);
   const rowVirtualizer = useVirtualizer({
     count: receiptItems.length,
     getScrollElement: () => parentRef.current,
     estimateSize: () => 70,
     overscan: 5,
-  })
+  });
 
   // ─── Publish Receipt ─────────────────────────────────────────────────────
   const handlePublishReceipt = async () => {
-    setIsPublishing(true)
+    setIsPublishing(true);
     try {
-      const id = crypto.randomUUID()
+      const id = crypto.randomUUID();
       const receiptData: SharedReceipt = {
         id,
-        title: receiptTitle || 'Unnamed Receipt',
+        title: receiptTitle || "Unnamed Receipt",
         people,
         items: receiptItems,
         totals: calculateTotals(),
         grandTotal: receiptItems.reduce((sum, item) => sum + item.price, 0),
         createdAt: new Date().toISOString(),
-      }
+      };
 
-      const url = await publishReceipt(receiptData)
-      setPublishedUrl(id)
+      const url = await publishReceipt(receiptData);
+      setPublishedUrl(id);
     } catch (error) {
-      console.error('Error publishing receipt:', error)
-      setOcrError('Failed to publish receipt')
+      console.error("Error publishing receipt:", error);
+      setOcrError("Failed to publish receipt");
     } finally {
-      setIsPublishing(false)
+      setIsPublishing(false);
     }
-  }
+  };
 
   return {
     people,
@@ -602,6 +675,6 @@ export function useMoneySplit() {
     activeTab,
     setActiveTab,
     calculateTotals,
-  }
+    getPersonItems,
+  };
 }
-

--- a/hooks/use-money-split.tsx
+++ b/hooks/use-money-split.tsx
@@ -1,0 +1,607 @@
+'use client'
+
+import React, { useState, useRef, useMemo, useCallback } from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
+
+import { Person, ReceiptItem, EditableItem, SharedReceipt } from '@/types'
+import { processReceiptOCR } from '@/app/actions/ocr'
+import { publishReceipt } from '@/app/actions/share'
+
+export function useMoneySplit() {
+  // ─── state definitions ─────────────────────────────────────────────────
+  const [people, setPeople] = useState<Person[]>([])
+  const [newPersonName, setNewPersonName] = useState('')
+  const [receiptItems, setReceiptItems] = useState<ReceiptItem[]>([])
+  const [newItemName, setNewItemName] = useState('')
+  const [newItemPrice, setNewItemPrice] = useState('')
+  const [activeTab, setActiveTab] = useState('people')
+  const [isProcessingOCR, setIsProcessingOCR] = useState(false)
+  const [ocrError, setOcrError] = useState<string | null>(null)
+  const [ocrSuccess, setOcrSuccess] = useState<string | null>(null)
+  const [selectedLanguage, setSelectedLanguage] = useState('auto')
+  const [editableItems, setEditableItems] = useState<EditableItem[]>([])
+  const [showPersonItems, setShowPersonItems] = useState<string | null>(null)
+  const [draggedItem, setDraggedItem] = useState<ReceiptItem | null>(null)
+  const [showSplitDialog, setShowSplitDialog] = useState(false)
+  const [splitDialogType, setSplitDialogType] = useState<'equal' | 'unequal'>('equal')
+  const [tempEqualSplitPeople, setTempEqualSplitPeople] = useState<string[]>([])
+  const [tempUnequalSplit, setTempUnequalSplit] = useState<{ personId: string; amount: number }[]>([])
+  const [currentPage, setCurrentPage] = useState(1)
+  const [pageSize, setPageSize] = useState(10)
+  const [splitItemsPage, setSplitItemsPage] = useState(1)
+  const [splitItemsPageSize, setSplitItemsPageSize] = useState(5)
+  const [unsplitItemsPage, setUnsplitItemsPage] = useState(1)
+  const [unsplitItemsPageSize, setUnsplitItemsPageSize] = useState(5)
+  const [isPublishing, setIsPublishing] = useState(false)
+  const [publishedUrl, setPublishedUrl] = useState<string | null>(null)
+  const [receiptTitle, setReceiptTitle] = useState('')
+
+  const fileInputRef = useRef<HTMLInputElement>(null) as React.RefObject<HTMLInputElement>
+
+  // ─── “People” Tab 相關函式 ────────────────────────────────────────────────
+  const addPerson = () => {
+    if (newPersonName.trim()) {
+      const newPerson: Person = {
+        id: Date.now().toString(),
+        name: newPersonName.trim(),
+      }
+      setPeople([...people, newPerson])
+      setNewPersonName('')
+    }
+  }
+
+  const removePerson = (id: string) => {
+    setPeople(people.filter((p) => p.id !== id))
+    setReceiptItems((items) =>
+      items.map((item) => ({
+        ...item,
+        assignedTo: item.assignedTo === id ? undefined : item.assignedTo,
+        equalSplitPeople: item.equalSplitPeople?.filter((pid) => pid !== id),
+        unequalSplit: item.unequalSplit?.filter((split) => split.personId !== id),
+        splitType: item.assignedTo === id ? 'unsplit' : item.splitType,
+      }))
+    )
+  }
+
+  // ─── “Receipt” Tab 相關函式 ───────────────────────────────────────────────
+  const addReceiptItem = useCallback(() => {
+    if (newItemName.trim() && newItemPrice.trim()) {
+      setReceiptItems((prev) => [
+        ...prev,
+        {
+          id: Date.now().toString(),
+          name: newItemName.trim(),
+          price: Number.parseFloat(newItemPrice),
+          splitType: 'unsplit',
+        },
+      ])
+      setNewItemName('')
+      setNewItemPrice('')
+    }
+  }, [newItemName, newItemPrice])
+
+  const removeReceiptItem = (id: string) => {
+    setReceiptItems(receiptItems.filter((item) => item.id !== id))
+  }
+
+  const handleReceiptUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (!file) return
+
+    setIsProcessingOCR(true)
+    setOcrError(null)
+    setOcrSuccess(null)
+
+    try {
+      const formData = new FormData()
+      formData.append('receipt', file)
+      formData.append('language', selectedLanguage)
+
+      const result = await processReceiptOCR(formData)
+
+      if (result.success && result.items && result.items.length > 0) {
+        const newEditableItems: EditableItem[] = result.items.map((item, index) => ({
+          id: (Date.now() + index).toString(),
+          name: item.name,
+          price: item.price.toString(),
+          isEditing: false,
+        }))
+
+        setEditableItems(newEditableItems)
+        setActiveTab('receipt')
+        setOcrSuccess(`Successfully extracted ${result.items.length} items from your receipt!`)
+        setOcrError(null)
+      } else if (result.success && result.items && result.items.length === 0) {
+        setOcrError('No items with prices were found in the receipt. You can add items manually below.')
+      } else {
+        setOcrError(result.error || 'Failed to process receipt')
+      }
+    } catch (error) {
+      setOcrError('Error processing receipt. Please try again.')
+    } finally {
+      setIsProcessingOCR(false)
+      event.target.value = ''
+    }
+  }
+
+  const updateEditableItem = (id: string, field: 'name' | 'price', value: string) => {
+    setEditableItems((items) => items.map((item) => (item.id === id ? { ...item, [field]: value } : item)))
+  }
+
+  const startEditingItem = (id: string) => {
+    setEditableItems((items) => items.map((item) => (item.id === id ? { ...item, isEditing: true } : item)))
+  }
+
+  const saveEditableItem = (id: string) => {
+    setEditableItems((items) => items.map((item) => (item.id === id ? { ...item, isEditing: false } : item)))
+  }
+
+  const removeEditableItem = (id: string) => {
+    setEditableItems((items) => items.filter((item) => item.id !== id))
+  }
+
+  const addEditableItemsToReceipt = () => {
+    const newItems: ReceiptItem[] = editableItems.map((item) => ({
+      id: item.id,
+      name: item.name,
+      price: Number.parseFloat(item.price) || 0,
+      splitType: 'unsplit',
+    }))
+
+    setReceiptItems((prev) => [...prev, ...newItems])
+    setEditableItems([])
+  }
+
+  const exportData = () => {
+    const data = {
+      people,
+      receiptItems,
+      exportDate: new Date().toISOString(),
+    }
+
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `money-split-${new Date().toISOString().split('T')[0]}.json`
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+  }
+
+  const importData = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    if (!file) return
+
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      try {
+        const data = JSON.parse(e.target?.result as string)
+        if (data.people && data.receiptItems) {
+          setPeople(data.people)
+          setReceiptItems(data.receiptItems)
+          setOcrSuccess('Data imported successfully!')
+        } else {
+          setOcrError('Invalid file format')
+        }
+      } catch (error) {
+        setOcrError('Error reading file')
+      }
+    }
+    reader.readAsText(file)
+    event.target.value = ''
+  }
+
+  // ─── “Split Items” Tab 相關函式 ───────────────────────────────────────────
+  const updateItemSplitType = (
+    itemId: string,
+    splitType: 'individual' | 'equal' | 'unequal' | 'unsplit'
+  ) => {
+    setReceiptItems((items) =>
+      items.map((item) =>
+        item.id === itemId
+          ? {
+              ...item,
+              splitType,
+              assignedTo: undefined,
+              equalSplitPeople: [],
+              unequalSplit: [],
+            }
+          : item
+      )
+    )
+  }
+
+  const updateIndividualAssignment = (itemId: string, personId: string) => {
+    setReceiptItems((items) =>
+      items.map((item) =>
+        item.id === itemId ? { ...item, assignedTo: personId, splitType: 'individual' } : item
+      )
+    )
+  }
+
+  const updateEqualSplitPeople = (itemId: string, personId: string, checked: boolean) => {
+    setReceiptItems((items) =>
+      items.map((item) => {
+        if (item.id === itemId) {
+          const currentPeople = item.equalSplitPeople || []
+          const updatedPeople = checked ? [...currentPeople, personId] : currentPeople.filter((id) => id !== personId)
+          return { ...item, equalSplitPeople: updatedPeople }
+        }
+        return item
+      })
+    )
+  }
+
+  const selectAllForEqualSplit = (itemId: string, selectAll: boolean) => {
+    setReceiptItems((items) =>
+      items.map((item) => {
+        if (item.id === itemId) {
+          return {
+            ...item,
+            equalSplitPeople: selectAll ? people.map((p) => p.id) : [],
+          }
+        }
+        return item
+      })
+    )
+  }
+
+  const updateUnequalSplit = (itemId: string, personId: string, amount: number) => {
+    setReceiptItems((items) =>
+      items.map((item) => {
+        if (item.id === itemId) {
+          const currentSplit = item.unequalSplit || []
+          const existingIndex = currentSplit.findIndex((split) => split.personId === personId)
+
+          let updatedSplit
+          if (existingIndex >= 0) {
+            if (amount === 0) {
+              updatedSplit = currentSplit.filter((split) => split.personId !== personId)
+            } else {
+              updatedSplit = currentSplit.map((split) => (split.personId === personId ? { ...split, amount } : split))
+            }
+          } else if (amount > 0) {
+            updatedSplit = [...currentSplit, { personId, amount }]
+          } else {
+            updatedSplit = currentSplit
+          }
+
+          return { ...item, unequalSplit: updatedSplit }
+        }
+        return item
+      })
+    )
+  }
+
+  const resetItemToUnsplit = (itemId: string) => {
+    setReceiptItems((items) =>
+      items.map((item) =>
+        item.id === itemId
+          ? {
+              ...item,
+              splitType: 'unsplit',
+              assignedTo: undefined,
+              equalSplitPeople: [],
+              unequalSplit: [],
+            }
+          : item
+      )
+    )
+  }
+
+  // ─── “Visual Split” Tab 相關函式 ───────────────────────────────────────────
+  const handleDragStart = (item: ReceiptItem) => {
+    setDraggedItem(item)
+  }
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault()
+  }
+
+  const handleDropOnPerson = (personId: string) => {
+    if (draggedItem) {
+      updateIndividualAssignment(draggedItem.id, personId)
+      setDraggedItem(null)
+    }
+  }
+
+  const handleDropOnSplitArea = (splitType: 'equal' | 'unequal') => {
+    if (draggedItem) {
+      setSplitDialogType(splitType)
+      if (splitType === 'equal') {
+        setTempEqualSplitPeople(people.map((p) => p.id))
+      } else {
+        setTempUnequalSplit(people.map((p) => ({ personId: p.id, amount: 0 })))
+      }
+      setShowSplitDialog(true)
+    }
+  }
+
+  const confirmSplit = () => {
+    if (!draggedItem) return
+
+    if (splitDialogType === 'equal') {
+      setReceiptItems((items) =>
+        items.map((item) =>
+          item.id === draggedItem.id
+            ? {
+                ...item,
+                splitType: 'equal',
+                equalSplitPeople: tempEqualSplitPeople,
+              }
+            : item
+        )
+      )
+    } else {
+      setReceiptItems((items) =>
+        items.map((item) =>
+          item.id === draggedItem.id ? { ...item, splitType: 'unequal', unequalSplit: tempUnequalSplit } : item
+        )
+      )
+    }
+
+    setShowSplitDialog(false)
+    setDraggedItem(null)
+    setTempEqualSplitPeople([])
+    setTempUnequalSplit([])
+    setOcrError(null)
+  }
+
+  const cancelSplit = () => {
+    setShowSplitDialog(false)
+    setDraggedItem(null)
+    setTempEqualSplitPeople([])
+    setTempUnequalSplit([])
+  }
+
+  const validateEqualSplit = () => {
+    return tempEqualSplitPeople.length > 0
+  }
+
+  const validateUnequalSplit = () => {
+    if (!draggedItem) return false
+    const totalSplit = tempUnequalSplit.reduce((sum, split) => sum + split.amount, 0)
+    const itemTotal = Number(draggedItem.price.toFixed(2))
+    return Math.abs(totalSplit - itemTotal) < 0.01
+  }
+
+  const getSplitValidationMessage = () => {
+    if (!draggedItem) return ''
+
+    if (splitDialogType === 'equal') {
+      if (tempEqualSplitPeople.length === 0) {
+        return 'Please select at least one person'
+      }
+    } else {
+      const totalSplit = tempUnequalSplit.reduce((sum, split) => sum + split.amount, 0)
+      const itemTotal = Number(draggedItem.price.toFixed(2))
+      if (Math.abs(totalSplit - itemTotal) >= 0.01) {
+        return `Split total ($${totalSplit.toFixed(2)}) must equal item price ($${itemTotal.toFixed(2)})`
+      }
+    }
+    return ''
+  }
+
+  // ─── “Summary” Tab 所需函式 ──────────────────────────────────────────────
+  const calculateTotals = () => {
+    const totals: { [personId: string]: number } = {}
+    people.forEach((person) => {
+      totals[person.id] = 0
+    })
+
+    receiptItems.forEach((item) => {
+      if (item.splitType === 'individual' && item.assignedTo) {
+        totals[item.assignedTo] = (totals[item.assignedTo] || 0) + item.price
+      } else if (item.splitType === 'equal' && item.equalSplitPeople && item.equalSplitPeople.length > 0) {
+        const splitAmount = item.price / item.equalSplitPeople.length
+        item.equalSplitPeople.forEach((personId) => {
+          totals[personId] = (totals[personId] || 0) + splitAmount
+        })
+      } else if (item.splitType === 'unequal' && item.unequalSplit) {
+        item.unequalSplit.forEach((split) => {
+          totals[split.personId] = (totals[split.personId] || 0) + split.amount
+        })
+      }
+    })
+
+    return totals
+  }
+
+  const getPersonItems = (personId: string) => {
+    const items: Array<{ item: ReceiptItem; amount: number; type: string }> = []
+
+    receiptItems.forEach((item) => {
+      if (item.splitType === 'individual' && item.assignedTo === personId) {
+        items.push({ item, amount: item.price, type: 'Individual' })
+      } else if (item.splitType === 'equal' && item.equalSplitPeople?.includes(personId)) {
+        const splitAmount = item.price / (item.equalSplitPeople?.length || 1)
+        items.push({ item, amount: splitAmount, type: 'Equal Split' })
+      } else if (item.splitType === 'unequal' && item.unequalSplit) {
+        const split = item.unequalSplit.find((s) => s.personId === personId)
+        if (split) {
+          items.push({ item, amount: split.amount, type: 'Custom Split' })
+        }
+      }
+    })
+
+    return items
+  }
+
+  // ─── 分頁 & 計算函式 ─────────────────────────────────────────────────────
+  const paginatedItems = useMemo(() => {
+    const startIndex = (currentPage - 1) * pageSize
+    const endIndex = startIndex + pageSize
+    return receiptItems.slice(startIndex, endIndex)
+  }, [receiptItems, currentPage, pageSize])
+
+  const totalPages = Math.ceil(receiptItems.length / pageSize)
+
+  const paginatedSplitItems = useMemo(() => {
+    const startIndex = (splitItemsPage - 1) * splitItemsPageSize
+    const endIndex = startIndex + splitItemsPageSize
+    return receiptItems.slice(startIndex, endIndex)
+  }, [receiptItems, splitItemsPage, splitItemsPageSize])
+
+  const totalSplitPages = Math.ceil(receiptItems.length / splitItemsPageSize)
+
+  const unsplitItems = useMemo(() => {
+    return receiptItems.filter((item) => item.splitType === 'unsplit')
+  }, [receiptItems])
+
+  const splitItemsByPerson = useMemo(() => {
+    const splitItems: { [personId: string]: ReceiptItem[] } = {}
+    people.forEach((person) => {
+      splitItems[person.id] = []
+    })
+
+    receiptItems.forEach((item) => {
+      if (item.splitType === 'individual' && item.assignedTo) {
+        splitItems[item.assignedTo].push(item)
+      } else if (item.splitType === 'equal' && item.equalSplitPeople) {
+        item.equalSplitPeople.forEach((personId) => {
+          splitItems[personId].push(item)
+        })
+      } else if (item.splitType === 'unequal' && item.unequalSplit) {
+        item.unequalSplit.forEach((split) => {
+          splitItems[split.personId].push(item)
+        })
+      }
+    })
+
+    return splitItems
+  }, [receiptItems, people])
+
+  const totalUnsplitPages = Math.ceil(unsplitItems.length / unsplitItemsPageSize)
+
+  const paginatedUnsplitItems = useMemo(() => {
+    const filteredUnsplit = unsplitItems
+    const startIndex = (unsplitItemsPage - 1) * unsplitItemsPageSize
+    const endIndex = startIndex + unsplitItemsPageSize
+
+    if (startIndex >= filteredUnsplit.length && unsplitItemsPage > 1) {
+      setUnsplitItemsPage(1)
+      return filteredUnsplit.slice(0, unsplitItemsPageSize)
+    }
+
+    return filteredUnsplit.slice(startIndex, endIndex)
+  }, [unsplitItemsPage, unsplitItemsPageSize, unsplitItems])
+
+  const grandTotal = useMemo(
+    () => receiptItems.reduce((sum, item) => sum + item.price, 0),
+    [receiptItems]
+  )
+
+  const parentRef = useRef<HTMLDivElement>(null)
+  const rowVirtualizer = useVirtualizer({
+    count: receiptItems.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 70,
+    overscan: 5,
+  })
+
+  // ─── Publish Receipt ─────────────────────────────────────────────────────
+  const handlePublishReceipt = async () => {
+    setIsPublishing(true)
+    try {
+      const id = crypto.randomUUID()
+      const receiptData: SharedReceipt = {
+        id,
+        title: receiptTitle || 'Unnamed Receipt',
+        people,
+        items: receiptItems,
+        totals: calculateTotals(),
+        grandTotal: receiptItems.reduce((sum, item) => sum + item.price, 0),
+        createdAt: new Date().toISOString(),
+      }
+
+      const url = await publishReceipt(receiptData)
+      setPublishedUrl(id)
+    } catch (error) {
+      console.error('Error publishing receipt:', error)
+      setOcrError('Failed to publish receipt')
+    } finally {
+      setIsPublishing(false)
+    }
+  }
+
+  return {
+    people,
+    newPersonName,
+    setNewPersonName,
+    addPerson,
+    removePerson,
+    receiptItems,
+    editableItems,
+    newItemName,
+    newItemPrice,
+    selectedLanguage,
+    isProcessingOCR,
+    ocrError,
+    ocrSuccess,
+    receiptTitle,
+    grandTotal,
+    currentPage,
+    pageSize,
+    totalPages,
+    paginatedItems,
+    fileInputRef,
+    setSelectedLanguage,
+    handleReceiptUpload,
+    exportData,
+    importData,
+    updateEditableItem,
+    startEditingItem,
+    saveEditableItem,
+    removeEditableItem,
+    addEditableItemsToReceipt,
+    addReceiptItem,
+    removeReceiptItem,
+    setNewItemName,
+    setNewItemPrice,
+    setCurrentPage,
+    splitItemsPage,
+    splitItemsPageSize,
+    totalSplitPages,
+    paginatedSplitItems,
+    setSplitItemsPage,
+    setSplitItemsPageSize,
+    updateItemSplitType,
+    updateIndividualAssignment,
+    updateEqualSplitPeople,
+    selectAllForEqualSplit,
+    updateUnequalSplit,
+    unsplitItems,
+    splitItemsByPerson,
+    paginatedUnsplitItems,
+    unsplitItemsPage,
+    totalUnsplitPages,
+    setUnsplitItemsPage,
+    draggedItem,
+    handleDragStart,
+    handleDragOver,
+    handleDropOnPerson,
+    handleDropOnSplitArea,
+    resetItemToUnsplit,
+    isPublishing,
+    setReceiptTitle,
+    handlePublishReceipt,
+    publishedUrl,
+    showSplitDialog,
+    cancelSplit,
+    splitDialogType,
+    tempEqualSplitPeople,
+    setTempEqualSplitPeople,
+    tempUnequalSplit,
+    setTempUnequalSplit,
+    validateEqualSplit,
+    validateUnequalSplit,
+    getSplitValidationMessage,
+    confirmSplit,
+    activeTab,
+    setActiveTab,
+    calculateTotals,
+  }
+}
+


### PR DESCRIPTION
## Summary
- move all state and logic from `app/page.tsx` into new hook `useMoneySplit`
- drastically shrink `app/page.tsx` by consuming the hook

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408edf8070832191e1844b41eee16e