### PR TITLE
Use OpenAI file uploads for vision requests

### DIFF
--- a/scripts/simple-gpt-test.mjs
+++ b/scripts/simple-gpt-test.mjs
@@ -6,13 +6,28 @@ const endpoint = 'https://models.github.ai/inference';
 const model = 'openai/gpt-4.1';
 
 const bytes = await fs.readFile(new URL('../public/LargeReceipt.jpg', import.meta.url));
-const imageUrl = `data:image/jpeg;base64,${bytes.toString('base64')}`;
 
 const client = new OpenAI({ baseURL: endpoint, apiKey: token });
-const messages = [
-  { role: 'system', content: 'You are a helpful assistant that extracts items from receipts as JSON.' },
-  { role: 'user', content: [ { type: 'text', text: 'Extract items' }, { type: 'image_url', image_url: imageUrl } ] }
-];
 
-const res = await client.chat.completions.create({ model, messages, response_format: { type: 'json_object' }, temperature: 0 });
-console.log(res.choices[0].message.content);
+// Upload file for vision API
+const file = await client.files.create({
+  file: await OpenAI.toFile(bytes, 'LargeReceipt.jpg', { type: 'image/jpeg' }),
+  purpose: 'vision'
+});
+
+const res = await client.responses.create({
+  model,
+  input: [
+    {
+      role: 'user',
+      content: [
+        { type: 'input_text', text: 'Extract items' },
+        { type: 'input_image', file_id: file.id }
+      ]
+    }
+  ],
+  response_format: { type: 'json_object' },
+  temperature: 0
+});
+
+console.log(res.output_text);


### PR DESCRIPTION
## Summary
- send receipt images to OpenAI using the Files API
- adapt GPT sample script to upload the file and call the `responses` API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841dccee7a48321b873b139ae00ed0b